### PR TITLE
Effects: add brightness and speed to webUI

### DIFF
--- a/ESPixelStick.h
+++ b/ESPixelStick.h
@@ -49,7 +49,8 @@ const char BUILD_DATE[] = __DATE__;
 #define PIXEL_LIMIT     1360    /* Total pixel limit - 40.85ms for 8 universes */
 #define RENARD_LIMIT    2048    /* Channel limit for serial outputs */
 #define E131_TIMEOUT    1000    /* Force refresh every second an E1.31 packet is not seen */
-#define CONNECT_TIMEOUT 15000   /* 15 seconds */
+#define CLIENT_TIMEOUT  15      /* In station/client mode try to connection for 15 seconds */
+#define AP_TIMEOUT      60      /* In AP mode, wait 60 seconds for a connection or reboot */
 #define REBOOT_DELAY    100     /* Delay for rebooting once reboot flag is set */
 #define LOG_PORT        Serial  /* Serial port for console logging */
 
@@ -99,6 +100,8 @@ typedef struct {
     uint8_t     gateway[4];
     bool        dhcp;           /* Use DHCP? */
     bool        ap_fallback;    /* Fallback to AP if fail to associate? */
+    uint32_t    sta_timeout;    /* Timeout when connection as client (station) */
+    uint32_t    ap_timeout;     /* How long to wait in AP mode with no connection before rebooting */
 
     bool        udp_enabled;
     uint16_t    udp_port;

--- a/ESPixelStick.h
+++ b/ESPixelStick.h
@@ -110,7 +110,7 @@ typedef struct {
     String effect_name;
     CRGB effect_color;
     float effect_brightness;
-    uint16_t effect_delay;
+    uint16_t effect_speed;	/* 1..10 for web UI and MQTT */
     bool effect_reverse;
     bool effect_mirror;
     bool effect_allleds;

--- a/ESPixelStick.h
+++ b/ESPixelStick.h
@@ -106,8 +106,8 @@ typedef struct {
     /* Effects */
     String effect_name;
     CRGB effect_color;
-    uint8_t effect_brightness;
-    uint16_t effect_speed;
+    float effect_brightness;
+    uint16_t effect_delay;
     bool effect_reverse;
     bool effect_mirror;
     bool effect_allleds;

--- a/ESPixelStick.ino
+++ b/ESPixelStick.ino
@@ -640,8 +640,8 @@ void initWeb() {
     // Static Handler
     web.serveStatic("/", SPIFFS, "/www/").setDefaultFile("index.html");
 
-    // Raw config file Handler
-    web.serveStatic("/config.json", SPIFFS, "/config.json");
+    // Raw config file Handler - but only on station
+    //web.serveStatic("/config.json", SPIFFS, "/config.json").setFilter(ON_STA_FILTER);
 
     web.onNotFound([](AsyncWebServerRequest *request) {
         if (request->method() == HTTP_OPTIONS) {
@@ -758,6 +758,11 @@ void validateConfig() {
 
     if (config.effect_speed < 100)
         config.effect_speed = 100;
+
+    if (config.effect_brightness > 1.0)
+        config.effect_brightness = 1.0;
+    if (config.effect_brightness < 0.0)
+        config.effect_brightness = 0.0;
 
     if (config.effect_idletimeout == 0) {
         config.effect_idletimeout = 10;
@@ -1018,6 +1023,9 @@ void loadConfig() {
 
     // Validate it
     validateConfig();
+
+    effects.setFromConfig();
+
 }
 
 // Serialize the current config into a JSON string

--- a/ESPixelStick.ino
+++ b/ESPixelStick.ino
@@ -197,6 +197,14 @@ void setup() {
     pixels.show();
 #else
     updateConfig();
+    // Do one effects cycle as early as possible
+    if (config.ds == DataSource::WEB) {
+        effects.run();
+    }
+    // set the effect idle timer
+    idleTicker.attach(config.effect_idletimeout, idleTimeout);
+
+    serial.show();
 #endif
 
     // Configure the pwm outputs
@@ -834,6 +842,7 @@ void updateConfig() {
 
 #elif defined(ESPS_MODE_SERIAL)
     serial.begin(&SEROUT_PORT, config.serial_type, config.channel_count, config.baudrate);
+    effects.begin(&serial, config.channel_count / 3 );
 
 #endif
 

--- a/ESPixelStick.ino
+++ b/ESPixelStick.ino
@@ -882,7 +882,8 @@ void dsEffectConfig(JsonObject &json) {
         config.effect_mirror = effectsJson["mirror"];
         config.effect_allleds = effectsJson["allleds"];
         config.effect_reverse = effectsJson["reverse"];
-        config.effect_speed = effectsJson["speed"];
+        if (effectsJson.containsKey("speed"))
+            config.effect_speed = effectsJson["speed"];
         config.effect_color = { effectsJson["r"], effectsJson["g"], effectsJson["b"] };
         if (effectsJson.containsKey("brightness"))
             config.effect_brightness = effectsJson["brightness"];
@@ -1058,6 +1059,7 @@ void serializeConfig(String &jsonString, bool pretty, bool creds) {
     _effects["allleds"] = config.effect_allleds;
     _effects["reverse"] = config.effect_reverse;
     _effects["speed"] = config.effect_speed;
+    _effects["brightness"] = config.effect_brightness;
 
     _effects["r"] = config.effect_color.r;
     _effects["g"] = config.effect_color.g;

--- a/ESPixelStick.ino
+++ b/ESPixelStick.ino
@@ -522,6 +522,10 @@ void onMqttMessage(char* topic, char* payload,
             effects.setBrightness((float)root["brightness"] / 255.0);
         }
 
+        if (root.containsKey("delay")) {
+            effects.setDelay(root["delay"]);
+        }
+
         if (root.containsKey("color")) {
             effects.setColor({
                 root["color"]["r"],
@@ -568,6 +572,7 @@ void publishState() {
     color["g"] = effects.getColor().g;
     color["b"] = effects.getColor().b;
     root["brightness"] = effects.getBrightness()*255;
+    root["delay"] = effects.getDelay();
     if (!effects.getEffect().equalsIgnoreCase("Disabled")) {
         root["effect"] = effects.getEffect();
     }

--- a/ESPixelStick.ino
+++ b/ESPixelStick.ino
@@ -295,7 +295,7 @@ void initWifi() {
     while (WiFi.status() != WL_CONNECTED) {
         LOG_PORT.print(".");
         delay(500);
-        if (millis() - timeout > CONNECT_TIMEOUT) {
+        if (millis() - timeout > (1000 * config.sta_timeout) ){
             LOG_PORT.println("");
             LOG_PORT.println(F("*** Failed to connect ***"));
             break;
@@ -646,7 +646,7 @@ void initWeb() {
     web.serveStatic("/", SPIFFS, "/www/").setDefaultFile("index.html");
 
     // Raw config file Handler - but only on station
-    web.serveStatic("/config.json", SPIFFS, "/config.json").setFilter(ON_STA_FILTER);
+//  web.serveStatic("/config.json", SPIFFS, "/config.json").setFilter(ON_STA_FILTER);
 
     web.onNotFound([](AsyncWebServerRequest *request) {
         if (request->method() == HTTP_OPTIONS) {
@@ -868,7 +868,16 @@ void dsNetworkConfig(JsonObject &json) {
             config.gateway[i] = networkJson["gateway"][i];
         }
         config.dhcp = networkJson["dhcp"];
+        config.sta_timeout = networkJson["sta_timeout"] | CLIENT_TIMEOUT;
+        if (config.sta_timeout < 5) {
+            config.sta_timeout = 5;
+        }
+
         config.ap_fallback = networkJson["ap_fallback"];
+        config.ap_timeout = networkJson["ap_timeout"] | AP_TIMEOUT;
+        if (config.ap_timeout < 15) {
+            config.ap_timeout = 15;
+        }
 
         config.udp_enabled = networkJson["udp_enabled"];
         config.udp_port = networkJson["udp_port"] | ESPS_UDP_RAW_DEFAULT_PORT;
@@ -1059,7 +1068,10 @@ void serializeConfig(String &jsonString, bool pretty, bool creds) {
         gateway.add(config.gateway[i]);
     }
     network["dhcp"] = config.dhcp;
+    network["sta_timeout"] = config.sta_timeout;
+
     network["ap_fallback"] = config.ap_fallback;
+    network["ap_timeout"] = config.ap_timeout;
 
     network["udp_enabled"] = config.udp_enabled;
     network["udp_port"] = config.udp_port;

--- a/ESPixelStick.ino
+++ b/ESPixelStick.ino
@@ -522,8 +522,8 @@ void onMqttMessage(char* topic, char* payload,
             effects.setBrightness((float)root["brightness"] / 255.0);
         }
 
-        if (root.containsKey("delay")) {
-            effects.setDelay(root["delay"]);
+        if (root.containsKey("speed")) {
+            effects.setSpeed(root["speed"]);
         }
 
         if (root.containsKey("color")) {
@@ -572,7 +572,7 @@ void publishState() {
     color["g"] = effects.getColor().g;
     color["b"] = effects.getColor().b;
     root["brightness"] = effects.getBrightness()*255;
-    root["delay"] = effects.getDelay();
+    root["speed"] = effects.getSpeed();
     if (!effects.getEffect().equalsIgnoreCase("Disabled")) {
         root["effect"] = effects.getEffect();
     }
@@ -761,8 +761,10 @@ void validateConfig() {
         config.baudrate = BaudRate::BR_57600;
 #endif
 
-    if (config.effect_delay < 100)
-        config.effect_delay = 100;
+    if (config.effect_speed < 1)
+        config.effect_speed = 1;
+    if (config.effect_speed > 10)
+        config.effect_speed = 10;
 
     if (config.effect_brightness > 1.0)
         config.effect_brightness = 1.0;
@@ -901,8 +903,8 @@ void dsEffectConfig(JsonObject &json) {
         config.effect_mirror = effectsJson["mirror"];
         config.effect_allleds = effectsJson["allleds"];
         config.effect_reverse = effectsJson["reverse"];
-        if (effectsJson.containsKey("delay"))
-            config.effect_delay = effectsJson["delay"];
+        if (effectsJson.containsKey("speed"))
+            config.effect_speed = effectsJson["speed"];
         config.effect_color = { effectsJson["r"], effectsJson["g"], effectsJson["b"] };
         if (effectsJson.containsKey("brightness"))
             config.effect_brightness = effectsJson["brightness"];
@@ -1083,7 +1085,7 @@ void serializeConfig(String &jsonString, bool pretty, bool creds) {
     _effects["mirror"] = config.effect_mirror;
     _effects["allleds"] = config.effect_allleds;
     _effects["reverse"] = config.effect_reverse;
-    _effects["delay"] = config.effect_delay;
+    _effects["speed"] = config.effect_speed;
     _effects["brightness"] = config.effect_brightness;
 
     _effects["r"] = config.effect_color.r;

--- a/ESPixelStick.ino
+++ b/ESPixelStick.ino
@@ -637,10 +637,10 @@ void initWeb() {
         request->send(200, "text/json", jsonString);
     });
 
-    // Firmware upload handler
+    // Firmware upload handler - only in station mode
     web.on("/updatefw", HTTP_POST, [](__attribute__ ((unused)) AsyncWebServerRequest *request) {
         ws.textAll("X6");
-    }, handle_fw_upload);
+    }, handle_fw_upload).setFilter(ON_STA_FILTER);
 
     // Static Handler
     web.serveStatic("/", SPIFFS, "/www/").setDefaultFile("index.html");
@@ -659,10 +659,10 @@ void initWeb() {
 
     DefaultHeaders::Instance().addHeader(F("Access-Control-Allow-Origin"), "*");
 
-    // Config file upload handler
+    // Config file upload handler - only in station mode
     web.on("/config", HTTP_POST, [](__attribute__ ((unused)) AsyncWebServerRequest *request) {
         ws.textAll("X6");
-    }, handle_config_upload);
+    }, handle_config_upload).setFilter(ON_STA_FILTER);
 
     web.begin();
 

--- a/EffectEngine.cpp
+++ b/EffectEngine.cpp
@@ -25,7 +25,7 @@ const EffectDesc EFFECT_LIST[] = {
 // Effect defaults
 #define DEFAULT_EFFECT_NAME "Disabled"
 #define DEFAULT_EFFECT_COLOR { 183, 0, 255 }
-#define DEFAULT_EFFECT_BRIGHTNESS 255
+#define DEFAULT_EFFECT_BRIGHTNESS 1.0
 #define DEFAULT_EFFECT_REVERSE false
 #define DEFAULT_EFFECT_MIRROR false
 #define DEFAULT_EFFECT_ALLLEDS false
@@ -127,9 +127,9 @@ bool EffectEngine::isValidEffect(const String effectName) {
 }
 
 void EffectEngine::setPixel(uint16_t idx,  CRGB color) {
-    _ledDriver->setValue(3 * idx + 0, (color.r * _effectBrightness) >> 8);
-    _ledDriver->setValue(3 * idx + 1, (color.g * _effectBrightness) >> 8);
-    _ledDriver->setValue(3 * idx + 2, (color.b * _effectBrightness) >> 8);
+    _ledDriver->setValue(3 * idx + 0, (uint8_t)(color.r * _effectBrightness) );
+    _ledDriver->setValue(3 * idx + 1, (uint8_t)(color.g * _effectBrightness) );
+    _ledDriver->setValue(3 * idx + 2, (uint8_t)(color.b * _effectBrightness) );
 }
 
 void EffectEngine::setRange(uint16_t first, uint16_t len, CRGB color) {

--- a/EffectEngine.cpp
+++ b/EffectEngine.cpp
@@ -42,7 +42,7 @@ void EffectEngine::setFromDefaults() {
     config.effect_reverse = DEFAULT_EFFECT_REVERSE;
     config.effect_mirror = DEFAULT_EFFECT_MIRROR;
     config.effect_allleds = DEFAULT_EFFECT_ALLLEDS;
-    config.effect_speed = DEFAULT_EFFECT_SPEED;
+    config.effect_delay = DEFAULT_EFFECT_DELAY;
     setFromConfig();
 }
 
@@ -53,7 +53,21 @@ void EffectEngine::setFromConfig() {
     setReverse(config.effect_reverse);
     setMirror(config.effect_mirror);
     setAllLeds(config.effect_allleds);
-    setSpeed(config.effect_speed);
+    setDelay(config.effect_delay);
+}
+
+void EffectEngine::setBrightness(float brightness) {
+    _effectBrightness = brightness;
+    if (_effectBrightness > 1.0)
+        _effectBrightness = 1.0;
+    if (_effectBrightness < 0.0)
+        _effectBrightness = 0.0;
+}
+
+void EffectEngine::setDelay(uint16_t delay) {
+    _effectDelay = delay;
+    if (_effectDelay < MIN_EFFECT_DELAY)
+        _effectDelay = MIN_EFFECT_DELAY;
 }
 
 void EffectEngine::begin(DRIVER* ledDriver, uint16_t ledCount) {
@@ -65,10 +79,10 @@ void EffectEngine::begin(DRIVER* ledDriver, uint16_t ledCount) {
 
 void EffectEngine::run() {
     if (_initialized && _activeEffect && _activeEffect->func) {
-        if (millis() - _effectLastRun >= _effectDelay) {
+        if (millis() - _effectLastRun >= _effectWait) {
             _effectLastRun = millis();
-            uint16_t delay = (this->*_activeEffect->func)();
-            _effectDelay = max((int)delay, MIN_EFFECT_DELAY);
+            uint16_t wait = (this->*_activeEffect->func)();
+            _effectWait = max((int)wait, MIN_EFFECT_DELAY);
             _effectCounter++;
         }
     }
@@ -81,7 +95,7 @@ void EffectEngine::setEffect(const String effectName) {
             if (_activeEffect != &EFFECT_LIST[effect]) {
                 _activeEffect = &EFFECT_LIST[effect];
                 _effectLastRun = millis();
-                _effectDelay = MIN_EFFECT_DELAY;
+                _effectWait = MIN_EFFECT_DELAY;
                 _effectCounter = 0;
                 _effectStep = 0;
             }
@@ -204,7 +218,7 @@ uint16_t EffectEngine::effectChase() {
     }
 
     _effectStep = (1+_effectStep) % lc;
-    return _effectSpeed / 32;
+    return _effectDelay / 32;
 }
 
 uint16_t EffectEngine::effectRainbow() {
@@ -241,12 +255,12 @@ uint16_t EffectEngine::effectRainbow() {
     }
 
     _effectStep = (1+_effectStep) & 0xFF;
-    return _effectSpeed / 256;
+    return _effectDelay / 256;
 }
 
 uint16_t EffectEngine::effectBlink() {
     // The Blink effect uses two "time slots": on, off
-    // Using default speed, a complete sequence takes 2s.
+    // Using default delay, a complete sequence takes 2s.
     if (_effectStep % 2) {
       clearAll();
     } else {
@@ -254,12 +268,12 @@ uint16_t EffectEngine::effectBlink() {
     }
 
     _effectStep = (1+_effectStep) % 2;
-    return _effectSpeed / 1;
+    return _effectDelay / 1;
 }
 
 uint16_t EffectEngine::effectFlash() {
     // The Flash effect uses 6 "time slots": on, off, on, off, off, off
-    // Using default speed, a complete sequence takes 2s.
+    // Using default delay, a complete sequence takes 2s.
     // Prevent errors if we come from another effect with more steps
     _effectStep = _effectStep % 6;
 
@@ -273,7 +287,7 @@ uint16_t EffectEngine::effectFlash() {
     }
 
     _effectStep = (1+_effectStep) % 6;
-    return _effectSpeed / 3;
+    return _effectDelay / 3;
 }
 
 uint16_t EffectEngine::effectFireFlicker() {
@@ -284,12 +298,12 @@ uint16_t EffectEngine::effectFireFlicker() {
     setPixel(i, CRGB { max(_effectColor.r - flicker, 0), max(_effectColor.g - flicker, 0), max(_effectColor.b - flicker, 0) });
   }
   _effectStep = (1+_effectStep) % _ledCount;
-  return _effectSpeed / 10;
+  return _effectDelay / 10;
 }
 
 uint16_t EffectEngine::effectLightning() {
   static byte maxFlashes;
-  static int timeslot = _effectSpeed / 1000; // 1ms
+  static int timeslot = _effectDelay / 1000; // 1ms
   int flashPause = 10; // 10ms
   uint16_t ledStart = random(_ledCount);
   uint16_t ledLen = random(1, _ledCount - ledStart);
@@ -333,7 +347,7 @@ uint16_t EffectEngine::effectBreathe() {
    * Subtle "breathing" effect, works best with gamma correction on.
    *
    * The average resting respiratory rate of an adult is 12–18 breaths/minute.
-   * We use 12 breaths/minute = 5.0s/breath at the default _effectSpeed.
+   * We use 12 breaths/minute = 5.0s/breath at the default _effectDelay.
    * The tidal volume (~0.5l) is much less than the total lung capacity,
    * so we vary only between 75% and 100% of the set brightness.
    *
@@ -350,9 +364,9 @@ uint16_t EffectEngine::effectBreathe() {
    * for a nice explanation of the math.
    */
   // sin() is in radians, so 2*PI rad is a full period; compiler should optimize.
-  float val = (exp(sin(millis()/(_effectSpeed*5.0)*2*PI)) - 0.367879441) * 0.106364766 + 0.75;
+  float val = (exp(sin(millis()/(_effectDelay*5.0)*2*PI)) - 0.367879441) * 0.106364766 + 0.75;
   setAll({_effectColor.r*val, _effectColor.g*val, _effectColor.b*val});
-  return _effectSpeed / 40; // update every 25ms
+  return _effectDelay / 40; // update every 25ms
 }
 
 void EffectEngine::sendUDPData() {

--- a/EffectEngine.cpp
+++ b/EffectEngine.cpp
@@ -29,6 +29,7 @@ const EffectDesc EFFECT_LIST[] = {
 #define DEFAULT_EFFECT_REVERSE false
 #define DEFAULT_EFFECT_MIRROR false
 #define DEFAULT_EFFECT_ALLLEDS false
+#define DEFAULT_EFFECT_SPEED 6
 
 EffectEngine::EffectEngine() {
     // Initialize with defaults
@@ -42,7 +43,7 @@ void EffectEngine::setFromDefaults() {
     config.effect_reverse = DEFAULT_EFFECT_REVERSE;
     config.effect_mirror = DEFAULT_EFFECT_MIRROR;
     config.effect_allleds = DEFAULT_EFFECT_ALLLEDS;
-    config.effect_delay = DEFAULT_EFFECT_DELAY;
+    config.effect_speed = DEFAULT_EFFECT_SPEED;
     setFromConfig();
 }
 
@@ -53,7 +54,7 @@ void EffectEngine::setFromConfig() {
     setReverse(config.effect_reverse);
     setMirror(config.effect_mirror);
     setAllLeds(config.effect_allleds);
-    setDelay(config.effect_delay);
+    setSpeed(config.effect_speed);
 }
 
 void EffectEngine::setBrightness(float brightness) {
@@ -62,6 +63,12 @@ void EffectEngine::setBrightness(float brightness) {
         _effectBrightness = 1.0;
     if (_effectBrightness < 0.0)
         _effectBrightness = 0.0;
+}
+
+// Yukky maths here. Input speeds from 1..10 get mapped to 17782..100
+void EffectEngine::setSpeed(uint16_t speed) {
+    _effectSpeed = speed;
+    setDelay( pow (10, (10-speed)/4.0 +2 ) );
 }
 
 void EffectEngine::setDelay(uint16_t delay) {

--- a/EffectEngine.h
+++ b/EffectEngine.h
@@ -5,7 +5,7 @@
 
 #define MIN_EFFECT_DELAY 10
 #define MAX_EFFECT_DELAY 65535
-#define DEFAULT_EFFECT_SPEED 1000
+#define DEFAULT_EFFECT_DELAY 1000
 
 #if defined(ESPS_MODE_PIXEL)
     #define DRIVER PixelDriver
@@ -57,10 +57,10 @@ private:
     using timeType = decltype(millis());
 
     const EffectDesc* _activeEffect = nullptr;      /* Pointer to the active effect descriptor */
-    uint32_t _effectDelay           = 0;            /* How long to wait for the effect to run again */
+    uint32_t _effectWait            = 0;            /* How long to wait for the effect to run again */
     timeType _effectLastRun         = 0;            /* When did the effect last run ? in millis() */
     uint32_t _effectCounter         = 0;            /* Counter for the number of calls to the active effect */
-    uint16_t _effectSpeed           = 1024;         /* Externally controlled effect speed [MIN_EFFECT_DELAY, MAX_EFFECT_DELAY]*/
+    uint16_t _effectDelay           = 1024;         /* Externally controlled effect speed [MIN_EFFECT_DELAY, MAX_EFFECT_DELAY]*/
     bool _effectReverse             = false;        /* Externally controlled effect reverse option */
     bool _effectMirror              = false;        /* Externally controlled effect mirroring (start at center) */
     bool _effectAllLeds             = false;        /* Externally controlled effect all leds = 1st led */
@@ -85,8 +85,8 @@ public:
     bool getReverse()                       { return _effectReverse; }
     bool getMirror()                        { return _effectMirror; }
     bool getAllLeds()                       { return _effectAllLeds; }
-    uint32_t getBrightness()                { return _effectBrightness; }
-    uint16_t getSpeed()                     { return _effectSpeed; }
+    float getBrightness()                   { return _effectBrightness; }
+    uint16_t getDelay()                     { return _effectDelay; }
     CRGB getColor()                         { return _effectColor; }
 
     int getEffectCount();
@@ -100,8 +100,10 @@ public:
     void setReverse(bool reverse)           { _effectReverse = reverse; }
     void setMirror(bool mirror)             { _effectMirror = mirror; }
     void setAllLeds(bool allleds)           { _effectAllLeds = allleds; }
-    void setBrightness(float brightness)    { _effectBrightness = brightness; }
-    void setSpeed(uint16_t speed)           { _effectSpeed = speed; }
+//  void setBrightness(float brightness)    { _effectBrightness = brightness; }
+//  void setDelay(uint16_t delay)           { _effectDelay = delay; }
+    void setBrightness(float brightness);
+    void setDelay(uint16_t delay);
     void setColor(CRGB color)               { _effectColor = color; }
 
     // Effect functions

--- a/EffectEngine.h
+++ b/EffectEngine.h
@@ -60,7 +60,8 @@ private:
     uint32_t _effectWait            = 0;            /* How long to wait for the effect to run again */
     timeType _effectLastRun         = 0;            /* When did the effect last run ? in millis() */
     uint32_t _effectCounter         = 0;            /* Counter for the number of calls to the active effect */
-    uint16_t _effectDelay           = 1024;         /* Externally controlled effect speed [MIN_EFFECT_DELAY, MAX_EFFECT_DELAY]*/
+    uint16_t _effectSpeed           = 6;            /* Externally controlled effect speed 1..10 */
+    uint16_t _effectDelay           = 1000;         /* Internal representation of speed */
     bool _effectReverse             = false;        /* Externally controlled effect reverse option */
     bool _effectMirror              = false;        /* Externally controlled effect mirroring (start at center) */
     bool _effectAllLeds             = false;        /* Externally controlled effect all leds = 1st led */
@@ -87,6 +88,7 @@ public:
     bool getAllLeds()                       { return _effectAllLeds; }
     float getBrightness()                   { return _effectBrightness; }
     uint16_t getDelay()                     { return _effectDelay; }
+    uint16_t getSpeed()                     { return _effectSpeed; }
     CRGB getColor()                         { return _effectColor; }
 
     int getEffectCount();
@@ -100,9 +102,8 @@ public:
     void setReverse(bool reverse)           { _effectReverse = reverse; }
     void setMirror(bool mirror)             { _effectMirror = mirror; }
     void setAllLeds(bool allleds)           { _effectAllLeds = allleds; }
-//  void setBrightness(float brightness)    { _effectBrightness = brightness; }
-//  void setDelay(uint16_t delay)           { _effectDelay = delay; }
     void setBrightness(float brightness);
+    void setSpeed(uint16_t speed);
     void setDelay(uint16_t delay);
     void setColor(CRGB color)               { _effectColor = color; }
 

--- a/EffectEngine.h
+++ b/EffectEngine.h
@@ -64,8 +64,8 @@ private:
     bool _effectReverse             = false;        /* Externally controlled effect reverse option */
     bool _effectMirror              = false;        /* Externally controlled effect mirroring (start at center) */
     bool _effectAllLeds             = false;        /* Externally controlled effect all leds = 1st led */
-    uint8_t _effectBrightness       = 255;          /* Externally controlled effect brightness [0, 255] */
-    CRGB _effectColor               = {0,0,0};          /* Externally controlled effect color */
+    float _effectBrightness         = 1.0;          /* Externally controlled effect brightness [0, 255] */
+    CRGB _effectColor               = {0,0,0};      /* Externally controlled effect color */
 
     uint32_t _effectStep            = 0;            /* Shared mutable effect step counter */
 
@@ -99,8 +99,8 @@ public:
     void setEffect(const String effectName);
     void setReverse(bool reverse)           { _effectReverse = reverse; }
     void setMirror(bool mirror)             { _effectMirror = mirror; }
-    void setAllLeds(bool allleds)            { _effectAllLeds = allleds; }
-    void setBrightness(uint8_t brightness)  { _effectBrightness = brightness; }
+    void setAllLeds(bool allleds)           { _effectAllLeds = allleds; }
+    void setBrightness(float brightness)    { _effectBrightness = brightness; }
     void setSpeed(uint16_t speed)           { _effectSpeed = speed; }
     void setColor(CRGB color)               { _effectColor = color; }
 

--- a/html/index.html
+++ b/html/index.html
@@ -387,10 +387,10 @@
               </div>
             </div>
             <div class="form-group">
-              <label class="control-label col-sm-2" for="t_speed">Effect Speed</label>
-              <div class="col-sm-3"><input type="number" step="10" class="form-control" id="t_speed" name="t_speed" title="Effect Speed"></div>
+              <label class="control-label col-sm-2" for="t_delay">Effect Interval</label>
+              <div class="col-sm-3"><input type="number" step="10" class="form-control" id="t_delay" name="t_delay" title="Effect interval is mS."></div>
               <label class="control-label col-sm-2" for="t_brightness">Effect Brightness</label>
-              <div class="col-sm-3"><input type="number" step="1" class="form-control" id="t_brightness" name="t_brightness" title="Effect Brightness"></div>
+              <div class="col-sm-3"><input type="number" step="0.1" class="form-control" id="t_brightness" name="t_brightness" title="Effect Brightness"></div>
             </div>
           </div>
 

--- a/html/index.html
+++ b/html/index.html
@@ -388,7 +388,9 @@
             </div>
             <div class="form-group">
               <label class="control-label col-sm-2" for="t_speed">Effect Speed</label>
-              <div class="col-sm-10"><input type="number" step="0.1" class="form-control" id="t_speed" name="t_speed" placeholder="Effect Speed"></div>
+              <div class="col-sm-3"><input type="number" step="10" class="form-control" id="t_speed" name="t_speed" title="Effect Speed"></div>
+              <label class="control-label col-sm-2" for="t_brightness">Effect Brightness</label>
+              <div class="col-sm-3"><input type="number" step="1" class="form-control" id="t_brightness" name="t_brightness" title="Effect Brightness"></div>
             </div>
           </div>
 

--- a/html/index.html
+++ b/html/index.html
@@ -391,8 +391,8 @@
               </div>
             </div>
             <div class="form-group">
-              <label class="control-label col-sm-2" for="t_delay">Effect Interval</label>
-              <div class="col-sm-3"><input type="number" step="10" class="form-control" id="t_delay" name="t_delay" title="Effect interval is mS."></div>
+              <label class="control-label col-sm-2" for="t_speed">Effect Speed</label>
+              <div class="col-sm-3"><input type="number" min="1" max="10" step="1" class="form-control" id="t_speed" name="t_speed" title="Effect speed, 1(slowest) to 10 (fastest)"></div>
               <label class="control-label col-sm-2" for="t_brightness">Effect Brightness</label>
               <div class="col-sm-3"><input type="number" step="0.1" class="form-control" id="t_brightness" name="t_brightness" title="Effect Brightness"></div>
             </div>

--- a/html/index.html
+++ b/html/index.html
@@ -114,6 +114,10 @@
             <label class="control-label col-sm-2" for="hostname">Hostname</label>
             <div class="col-sm-10"><input type="text" class="form-control has-error" id="hostname" name="hostname" placeholder="Enter Hostname"></div>
           </div>
+          <div class="form-group" id="fg_staTimeout">
+            <label class="control-label col-sm-2" for="staTimeout">Client Timeout</label>
+            <div class="col-sm-10"><input type="text" class="form-control has-error" id="staTimeout" name="staTimeout" title="When connecting as a client, this is the timeout in seconds."></div>
+          </div>
           <div class="form-group">
             <div class="col-sm-offset-2 col-sm-10">
               <div class="checkbox"><label><input type="checkbox" id="dhcp" name="dhcp"> Use DHCP</label></div>

--- a/html/script.js
+++ b/html/script.js
@@ -162,6 +162,16 @@ $(function() {
       }
     });
 
+    // Effect brightness field
+    $('#t_brightness').change(function() {
+      var json = { 'brightness': $(this).val() };
+      var tmode = $('#tmode option:selected').val();
+
+      if (typeof effectInfo[tmode].wsTCode !== 'undefined') {
+          wsEnqueue( effectInfo[tmode].wsTCode + JSON.stringify(json) );
+      }
+    });
+
     // Test mode toggles
     $('#tmode').change(hideShowTestSections());
 
@@ -801,6 +811,7 @@ function getEffectInfo(data) {
     $('#t_mirror').prop('checked', running.mirror);
     $('#t_allleds').prop('checked', running.allleds);
     $('#t_speed').val(running.speed);
+    $('#t_brightness').val(running.brightness);
     $('#t_startenabled').prop('checked', running.startenabled);
     $('#t_idleenabled').prop('checked', running.idleenabled);
     $('#t_idletimeout').val(running.idletimeout);
@@ -987,7 +998,7 @@ function submitStartupEffect() {
                 'r': temp[1],
                 'g': temp[2],
                 'b': temp[3],
-                'brightness': 255,
+                'brightness': parseInt($('#t_brightness').val()),
                 'startenabled': $('#t_startenabled').prop('checked'),
                 'idleenabled': $('#t_idleenabled').prop('checked'),
                 'idletimeout': parseInt($('#t_idletimeout').val()),

--- a/html/script.js
+++ b/html/script.js
@@ -152,9 +152,9 @@ $(function() {
       }
     });
 
-    // Effect speed field
-    $('#t_speed').change(function() {
-      var json = { 'speed': $(this).val() };
+    // Effect delay field
+    $('#t_delay').change(function() {
+      var json = { 'delay': $(this).val() };
       var tmode = $('#tmode option:selected').val();
 
       if (typeof effectInfo[tmode].wsTCode !== 'undefined') {
@@ -810,7 +810,7 @@ function getEffectInfo(data) {
     $('#t_reverse').prop('checked', running.reverse);
     $('#t_mirror').prop('checked', running.mirror);
     $('#t_allleds').prop('checked', running.allleds);
-    $('#t_speed').val(running.speed);
+    $('#t_delay').val(running.delay);
     $('#t_brightness').val(running.brightness);
     $('#t_startenabled').prop('checked', running.startenabled);
     $('#t_idleenabled').prop('checked', running.idleenabled);
@@ -994,11 +994,11 @@ function submitStartupEffect() {
                 'mirror': $('#t_mirror').prop('checked'),
                 'allleds': $('#t_allleds').prop('checked'),
                 'reverse': $('#t_reverse').prop('checked'),
-                'speed': parseInt($('#t_speed').val()),
+                'delay': parseInt($('#t_delay').val()),
                 'r': temp[1],
                 'g': temp[2],
                 'b': temp[3],
-                'brightness': parseInt($('#t_brightness').val()),
+                'brightness': parseFloat($('#t_brightness').val()),
                 'startenabled': $('#t_startenabled').prop('checked'),
                 'idleenabled': $('#t_idleenabled').prop('checked'),
                 'idletimeout': parseInt($('#t_idletimeout').val()),

--- a/html/script.js
+++ b/html/script.js
@@ -152,9 +152,9 @@ $(function() {
       }
     });
 
-    // Effect delay field
-    $('#t_delay').change(function() {
-      var json = { 'delay': $(this).val() };
+    // Effect speed field
+    $('#t_speed').change(function() {
+      var json = { 'speed': $(this).val() };
       var tmode = $('#tmode option:selected').val();
 
       if (typeof effectInfo[tmode].wsTCode !== 'undefined') {
@@ -822,7 +822,7 @@ function getEffectInfo(data) {
     $('#t_reverse').prop('checked', running.reverse);
     $('#t_mirror').prop('checked', running.mirror);
     $('#t_allleds').prop('checked', running.allleds);
-    $('#t_delay').val(running.delay);
+    $('#t_speed').val(running.speed);
     $('#t_brightness').val(running.brightness);
     $('#t_startenabled').prop('checked', running.startenabled);
     $('#t_idleenabled').prop('checked', running.idleenabled);
@@ -1007,7 +1007,7 @@ function submitStartupEffect() {
                 'mirror': $('#t_mirror').prop('checked'),
                 'allleds': $('#t_allleds').prop('checked'),
                 'reverse': $('#t_reverse').prop('checked'),
-                'delay': parseInt($('#t_delay').val()),
+                'speed': parseInt($('#t_speed').val()),
                 'r': temp[1],
                 'g': temp[2],
                 'b': temp[3],

--- a/html/script.js
+++ b/html/script.js
@@ -249,6 +249,9 @@ $(function() {
     $('#hostname').keyup(function() {
         wifiValidation();
     });
+    $('#staTimeout').keyup(function() {
+        wifiValidation();
+    });
     $('#ssid').keyup(function() {
         wifiValidation();
     });
@@ -297,6 +300,14 @@ function wifiValidation() {
     } else {
         $('#fg_hostname').removeClass('has-success');
         $('#fg_hostname').addClass('has-error');
+        WifiSaveDisabled = true;
+    }
+    if ($('#staTimeout').val() >= 5) {
+        $('#fg_staTimeout').removeClass('has-error');
+        $('#fg_staTimeout').addClass('has-success');
+    } else {
+        $('#fg_staTimeout').removeClass('has-success');
+        $('#fg_staTimeout').addClass('has-error');
         WifiSaveDisabled = true;
     }
     if ($('#ssid').val().length <= 32) {
@@ -572,6 +583,7 @@ function getConfig(data) {
     $('#ssid').val(config.network.ssid);
     $('#password').val(config.network.passphrase);
     $('#hostname').val(config.network.hostname);
+    $('#staTimeout').val(config.network.sta_timeout);
     $('#dhcp').prop('checked', config.network.dhcp);
     if (config.network.dhcp) {
         $('.dhcp').addClass('hidden');
@@ -907,6 +919,7 @@ function submitWiFi() {
                 'ssid': $('#ssid').val(),
                 'passphrase': $('#password').val(),
                 'hostname': $('#hostname').val(),
+                'sta_timeout': $('#staTimeout').val(),
                 'ip': [parseInt(ip[0]), parseInt(ip[1]), parseInt(ip[2]), parseInt(ip[3])],
                 'netmask': [parseInt(netmask[0]), parseInt(netmask[1]), parseInt(netmask[2]), parseInt(netmask[3])],
                 'gateway': [parseInt(gateway[0]), parseInt(gateway[1]), parseInt(gateway[2]), parseInt(gateway[3])],

--- a/html/script.js
+++ b/html/script.js
@@ -239,10 +239,12 @@ $(function() {
 
     // Serial protocol toggles
     $('#s_proto').change(function() {
-        if ($('select[name=s_proto]').val() == '0')
+        var proto = $('#s_proto option:selected').text();
+        if (!proto.localeCompare('DMX512')) {
             $('#s_baud').prop('disabled', true);
-        else
+        } else if (!proto.localeCompare('Renard')) {
             $('#s_baud').prop('disabled', false);
+        }
     });
 
     // Hostname, SSID, and Password validation
@@ -1052,10 +1054,12 @@ function refreshSerial() {
     if (!proto.localeCompare('Renard')) {
         symbol = 10;
         size = size + 2;
+        $('#s_baud').prop('disabled', false);
     } else if (!proto.localeCompare('DMX512')) {
         symbol = 11;
         baud = 250000;
         $('#s_baud').val(baud);
+        $('#s_baud').prop('disabled', true);
     }
     var rate = symbol * 1000 / baud * size;
     var hz = 1000 / rate;

--- a/wshandler.h
+++ b/wshandler.h
@@ -390,6 +390,9 @@ void procT(uint8_t *data, AsyncWebSocketClient *client) {
             if (json.containsKey("speed")) {
                 effects.setSpeed(json["speed"]);
             }
+            if (json.containsKey("brightness")) {
+                effects.setBrightness(json["brightness"]);
+            }
             client->text("OK");
         }
     }

--- a/wshandler.h
+++ b/wshandler.h
@@ -249,7 +249,7 @@ void procG(uint8_t *data, AsyncWebSocketClient *client) {
             JsonObject &effect = json.createNestedObject("currentEffect");
             effect["name"] = (String)effects.getEffect() ? effects.getEffect() : "";
             effect["brightness"] = effects.getBrightness();
-            effect["delay"] = effects.getDelay();
+            effect["speed"] = effects.getSpeed();
             effect["r"] = effects.getColor().r;
             effect["g"] = effects.getColor().g;
             effect["b"] = effects.getColor().b;
@@ -385,8 +385,8 @@ void procT(uint8_t *data, AsyncWebSocketClient *client) {
                     effects.setAllLeds(json["allleds"]);
                 }
             }
-            if (json.containsKey("delay")) {
-                effects.setDelay(json["delay"]);
+            if (json.containsKey("speed")) {
+                effects.setSpeed(json["speed"]);
             }
             if (json.containsKey("brightness")) {
                 effects.setBrightness(json["brightness"]);

--- a/wshandler.h
+++ b/wshandler.h
@@ -249,7 +249,7 @@ void procG(uint8_t *data, AsyncWebSocketClient *client) {
             JsonObject &effect = json.createNestedObject("currentEffect");
             effect["name"] = (String)effects.getEffect() ? effects.getEffect() : "";
             effect["brightness"] = effects.getBrightness();
-            effect["speed"] = effects.getSpeed();
+            effect["delay"] = effects.getDelay();
             effect["r"] = effects.getColor().r;
             effect["g"] = effects.getColor().g;
             effect["b"] = effects.getColor().b;
@@ -277,8 +277,6 @@ void procG(uint8_t *data, AsyncWebSocketClient *client) {
                 effect["hasReverse"] = effects.getEffectInfo(i)->hasReverse;
                 effect["hasAllLeds"] = effects.getEffectInfo(i)->hasAllLeds;
                 effect["wsTCode"] = effects.getEffectInfo(i)->wsTCode;
-//              effect["brightness"] = effects.getBrightness();
-//              effect["speed"] = effects.getSpeed();
               }
             }
 
@@ -387,8 +385,8 @@ void procT(uint8_t *data, AsyncWebSocketClient *client) {
                     effects.setAllLeds(json["allleds"]);
                 }
             }
-            if (json.containsKey("speed")) {
-                effects.setSpeed(json["speed"]);
+            if (json.containsKey("delay")) {
+                effects.setDelay(json["delay"]);
             }
             if (json.containsKey("brightness")) {
                 effects.setBrightness(json["brightness"]);

--- a/wshandler.h
+++ b/wshandler.h
@@ -247,7 +247,11 @@ void procG(uint8_t *data, AsyncWebSocketClient *client) {
 
 // dump the current running effect options
             JsonObject &effect = json.createNestedObject("currentEffect");
-            effect["name"] = (String)effects.getEffect() ? effects.getEffect() : "";
+            if (config.ds == DataSource::E131) {
+                effect["name"] = "Disabled";
+            } else {
+                effect["name"] = (String)effects.getEffect() ? effects.getEffect() : "";
+            }
             effect["brightness"] = effects.getBrightness();
             effect["speed"] = effects.getSpeed();
             effect["r"] = effects.getColor().r;


### PR DESCRIPTION
Effects:   can now set effect brightness float 0 to 1.0
MQTT: brightness needs to be   0..255 Effects: rename speed to delay
MQTT: added effect delay to   pub and sub
Wifi: added Client Timeout to   webUI to change the default 15 sec connect timeout
Restrict firmware and config   upload to STA/client interface
Effects: webUI and MQTT now   use speed from 1 to 10 (fastest)
Effects: make effects work   with serial mode Serial: make webUI disable baud rate in DMX type
Web effects sync fix

